### PR TITLE
fixed 1.8 -> 1.9 enderman metadata translation

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/metadata/MetadataRewriter.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/metadata/MetadataRewriter.java
@@ -47,12 +47,8 @@ public class MetadataRewriter {
 							else entry.setValue(owner.toString());
 							break;
 						case BlockID:
-							int combined = (Integer) value;
-							int id = combined >> 4;
-							int data = combined & 0xF;
 							list.remove(entry);
-							list.add(new Metadata(metaIndex.getIndex(), MetaType1_8.Short, (short)id));
-							list.add(new Metadata(metaIndex.getIndex(), MetaType1_8.Byte, (byte)data));
+							list.add(new Metadata(metaIndex.getIndex(), MetaType1_8.Short, ((Integer) value).shortValue()));
 							break;
 						case VarInt:
 							if (metaIndex.getOldType() == MetaType1_8.Byte) {


### PR DESCRIPTION
Fixed a issue that crashed 1.8 clients on 1.9 servers because of invalid metadata.
This should fix #205 