### PR TITLE
Prevent allow flight player ability desync

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/packets/PlayerPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/packets/PlayerPackets.java
@@ -938,10 +938,11 @@ public class PlayerPackets {
 				handler(new PacketHandler() {
 					@Override
 					public void handle(PacketWrapper packetWrapper) throws Exception {
-						byte flags = packetWrapper.get(Type.BYTE, 0);
 						PlayerAbilities abilities = packetWrapper.user().get(PlayerAbilities.class);
-						abilities.setAllowFly((flags & 4) == 4);
-						abilities.setFlying((flags & 2) == 2);
+						if (abilities.isAllowFly()) {
+							byte flags = packetWrapper.get(Type.BYTE, 0);
+							abilities.setFlying((flags & 2) == 2);
+						}
 						packetWrapper.set(Type.FLOAT, 0, abilities.getFlySpeed());
 					}
 				});


### PR DESCRIPTION
The vanilla server only listens to a change in the flying status of player abilities, disregarding all other flags sent by the client.

This is necessary because in current viaversion, there's a race condiction that will allow 1.7 clients to continue flying after being set to survival, to reproduce it:
 - Be in creative mode (or just have allow flight ability set to true)
 - Spam space
 - Be set to survival mode (or just disable allow flight)
 - Sprint, and you can now toggle flight freely

This happens because spamming space sends packets to the server where you keep on reporting flying true/false and allow flight = true, due to latency, your packet with canFly=true comes in later than the last packet sent by the server with canFly=false. When in this state you can't fly from the client, but the moment you sprint, viarewind sends you an extra player abilities packet, where canFly will be set to true, allowing the client to fly.

This PR mimics the vanilla behaviour (at least as of 1.8 bukkit server) upon receiving a player abilities packet, that is:
```java
        if (player.abilities.canFly && player.abilities.isFlying != packet.isFlying()) {
            PlayerToggleFlightEvent event = new PlayerToggleFlightEvent(/*...*/);
            server.getPluginManager().callEvent(event);
            if (!event.isCancelled()) player.abilities.isFlying = packet.isFlying();
            else player.updateAbilities();
        }
```
if the event is cancelled the old abilities will be re-sent to the client and viarewind will be able to properly update from the outgoing packet