### PR TITLE
Change confirmTeleport to be off-thread (fixes #232)

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/bossbar/WitherBossBar.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/bossbar/WitherBossBar.java
@@ -187,7 +187,7 @@ public class WitherBossBar extends BossBar {
 
 		packetWrapper.write(Types1_8.METADATA_LIST, metadata);
 
-		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, true);
+		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, false);
 	}
 
 	private void updateLocation() {
@@ -200,7 +200,7 @@ public class WitherBossBar extends BossBar {
 		packetWrapper.write(Type.BYTE, (byte)0);
 		packetWrapper.write(Type.BOOLEAN, false);
 
-		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, true);
+		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, false);
 	}
 
 	private void updateMetadata() {
@@ -213,14 +213,14 @@ public class WitherBossBar extends BossBar {
 
 		packetWrapper.write(Types1_8.METADATA_LIST, metadata);
 
-		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, true);
+		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, false);
 	}
 
 	private void despawnWither() {
 		PacketWrapper packetWrapper = new PacketWrapper(0x13, null, this.connection);
 		packetWrapper.write(Type.VAR_INT_ARRAY_PRIMITIVE, new int[] {entityId});
 
-		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, true);
+		PacketUtil.sendPacket(packetWrapper, Protocol1_8TO1_9.class, true, false);
 	}
 
 	public void setPlayerLocation(double posX, double posY, double posZ, float yaw, float pitch) {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/PlayerPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/PlayerPackets.java
@@ -446,7 +446,7 @@ public class PlayerPackets {
 							if (pos.getPosX() == x && pos.getPosY() == y && pos.getPosZ() == z && pos.getYaw() == yaw && pos.getPitch() == pitch) {
 								PacketWrapper confirmTeleport = packetWrapper.create(0x00);
 								confirmTeleport.write(Type.VAR_INT, pos.getConfirmId());
-								PacketUtil.sendToServer(confirmTeleport, Protocol1_8TO1_9.class, true, false);
+								PacketUtil.sendToServer(confirmTeleport, Protocol1_8TO1_9.class, true, true);
 
 								pos.setConfirmId(-1);
 							}

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/PlayerPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/PlayerPackets.java
@@ -446,7 +446,7 @@ public class PlayerPackets {
 							if (pos.getPosX() == x && pos.getPosY() == y && pos.getPosZ() == z && pos.getYaw() == yaw && pos.getPitch() == pitch) {
 								PacketWrapper confirmTeleport = packetWrapper.create(0x00);
 								confirmTeleport.write(Type.VAR_INT, pos.getConfirmId());
-								PacketUtil.sendToServer(confirmTeleport, Protocol1_8TO1_9.class, true, true);
+								PacketUtil.sendToServer(confirmTeleport, Protocol1_8TO1_9.class, true, false);
 
 								pos.setConfirmId(-1);
 							}


### PR DESCRIPTION
There is a race condition where sendToServer & send called at the same time lead to the next allocated bytebuf having a decremented reference count.

While there should be a proper fix to this (most likely an overhaul to send & sendToServer in Viaversion), this mitigates the fix for now and allows boss bars to work correctly.