### PR TITLE
Eliminate insane Object allocation rate

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/chunks/ChunkPacketTransformer.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/chunks/ChunkPacketTransformer.java
@@ -1,6 +1,7 @@
 package de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.chunks;
 
 import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.items.ReplacementRegistry1_7_6_10to1_8;
+import de.gerrygames.viarewind.replacement.Replacement;
 import de.gerrygames.viarewind.storage.BlockState;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -25,15 +26,22 @@ public class ChunkPacketTransformer {
 				short blockData = (short) ((data[(dataSize + 1)] & 0xFF) << 8 | data[dataSize] & 0xFF);
 				dataSize += 2;
 
-				BlockState state = BlockState.rawToState(blockData);
-				state = ReplacementRegistry1_7_6_10to1_8.replace(state);
+				int id = BlockState.extractId(blockData);
+				int meta = BlockState.extractData(blockData);
 
-				buf.writeByte(state.getId());
+				Replacement replace = ReplacementRegistry1_7_6_10to1_8.getReplacement(id, meta);
+
+				if (replace != null) {
+					id = replace.getId();
+					meta = replace.replaceData(meta);
+				}
+
+				buf.writeByte(id);
 
 				if (j % 2 == 0) {
-					tmp = (byte) (state.getData() & 0xF);
+					tmp = (byte) (meta & 0xF);
 				} else {
-					blockDataBuf.writeByte(tmp | (state.getData() & 15) << 4);
+					blockDataBuf.writeByte(tmp | (meta & 15) << 4);
 				}
 			}
 		}

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/items/ReplacementRegistry1_7_6_10to1_8.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/items/ReplacementRegistry1_7_6_10to1_8.java
@@ -92,7 +92,14 @@ public class ReplacementRegistry1_7_6_10to1_8 {
 		return registry.replace(item);
 	}
 
-	public static BlockState replace(BlockState block) {
-		return registry.replace(block);
+	public static int replace(int raw) {
+		int data = BlockState.extractData(raw);
+		Replacement replace = registry.replace(BlockState.extractId(raw), data);
+		return replace != null ? BlockState.stateToRaw(replace.getId(), replace.replaceData(data)) : raw;
 	}
+
+	public static Replacement getReplacement(int id, int data) {
+		return registry.replace(id, data);
+	}
+
 }

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/packets/SpawnPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/packets/SpawnPackets.java
@@ -9,6 +9,7 @@ import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.metadata.MetadataR
 import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.storage.EntityTracker;
 import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.storage.GameProfileStorage;
 import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.types.Types1_7_6_10;
+import de.gerrygames.viarewind.replacement.Replacement;
 import de.gerrygames.viarewind.storage.BlockState;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
@@ -177,9 +178,14 @@ public class SpawnPackets {
 						int data = packetWrapper.get(Type.INT, 3);
 
 						if (type != null && type.isOrHasParent(Entity1_10Types.EntityType.FALLING_BLOCK)) {
-							BlockState state = new BlockState(data & 0xFFF, data >> 12 & 0xF);
-							state = ReplacementRegistry1_7_6_10to1_8.replace(state);
-							packetWrapper.set(Type.INT, 3, data = (state.getId() | state.getData() << 16));
+							int blockId = data & 0xFFF;
+							int blockData = data >> 12 & 0xF;
+							Replacement replace = ReplacementRegistry1_7_6_10to1_8.getReplacement(blockId, blockData);
+							if (replace != null) {
+								blockId = replace.getId();
+								blockData = replace.replaceData(blockData);
+							}
+							packetWrapper.set(Type.INT, 3, data = (blockId | blockData << 16));
 						}
 
 						if (data > 0) {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/items/ReplacementRegistry1_8to1_9.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/items/ReplacementRegistry1_8to1_9.java
@@ -64,7 +64,14 @@ public class ReplacementRegistry1_8to1_9 {
 		return registry.replace(item);
 	}
 
-	public static BlockState replace(BlockState block) {
-		return registry.replace(block);
+	public static int replace(int raw) {
+		int data = BlockState.extractData(raw);
+		Replacement replace = registry.replace(BlockState.extractId(raw), data);
+		return BlockState.stateToRaw(replace.getId(), replace.replaceData(data));
 	}
+
+	public static Replacement getReplacement(int id, int data) {
+		return registry.replace(id, data);
+	}
+
 }

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/SpawnPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/SpawnPackets.java
@@ -7,6 +7,7 @@ import de.gerrygames.viarewind.protocol.protocol1_8to1_9.entityreplacement.Shulk
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.items.ReplacementRegistry1_8to1_9;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.metadata.MetadataRewriter;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.EntityTracker;
+import de.gerrygames.viarewind.replacement.Replacement;
 import de.gerrygames.viarewind.storage.BlockState;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
@@ -92,9 +93,10 @@ public class SpawnPackets {
 							packetWrapper.set(Type.INT, 3, --data);
 						}
 						if (type.is(Entity1_10Types.EntityType.FALLING_BLOCK)) {
-							BlockState state = new BlockState(data & 0xFFF, data >> 12 & 0xF);
-							state = ReplacementRegistry1_8to1_9.replace(state);
-							packetWrapper.set(Type.INT, 3, state.getId() | state.getData() << 12);
+							int blockId = data & 0xFFF;
+							int blockData = data >> 12 & 0xF;
+							Replacement replace = ReplacementRegistry1_8to1_9.getReplacement(blockId, blockData);
+							packetWrapper.set(Type.INT, 3, replace.getId() | replace.replaceData(data) << 12);
 						}
 
 						if (data > 0) {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/WorldPackets.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/packets/WorldPackets.java
@@ -85,9 +85,8 @@ public class WorldPackets {
 					@Override
 					public void handle(PacketWrapper packetWrapper) throws Exception {
 						int combined = packetWrapper.get(Type.VAR_INT, 0);
-						BlockState state = BlockState.rawToState(combined);
-						state = ReplacementRegistry1_8to1_9.replace(state);
-						packetWrapper.set(Type.VAR_INT, 0, BlockState.stateToRaw(state));
+						int replacedCombined = ReplacementRegistry1_8to1_9.replace(combined);
+						packetWrapper.set(Type.VAR_INT, 0, replacedCombined);
 					}
 				});
 			}
@@ -107,9 +106,8 @@ public class WorldPackets {
 					@Override
 					public void handle(PacketWrapper packetWrapper) throws Exception {
 						for (BlockChangeRecord record : packetWrapper.get(Type.BLOCK_CHANGE_RECORD_ARRAY, 0)) {
-							BlockState state = BlockState.rawToState(record.getBlockId());
-							state = ReplacementRegistry1_8to1_9.replace(state);
-							record.setBlockId(BlockState.stateToRaw(state));
+							int replacedCombined = ReplacementRegistry1_8to1_9.replace(record.getBlockId());
+							record.setBlockId(replacedCombined);
 						}
 					}
 				});
@@ -204,9 +202,8 @@ public class WorldPackets {
 							if (section == null) continue;
 							for (int i = 0; i < section.getPaletteSize(); i++) {
 								int block = section.getPaletteEntry(i);
-								BlockState state = BlockState.rawToState(block);
-								state = ReplacementRegistry1_8to1_9.replace(state);
-								section.setPaletteEntry(i, BlockState.stateToRaw(state));
+								int replacedBlock = ReplacementRegistry1_8to1_9.replace(block);
+								section.setPaletteEntry(i, replacedBlock);
 							}
 						}
 
@@ -283,9 +280,8 @@ public class WorldPackets {
 						}
 						packetWrapper.set(Type.INT, 0, id);
 						if (id == 2001) {
-							BlockState state = BlockState.rawToState(packetWrapper.get(Type.INT, 1));
-							state = ReplacementRegistry1_8to1_9.replace(state);
-							packetWrapper.set(Type.INT, 1, BlockState.stateToRaw(state));
+							int replacedBlock = ReplacementRegistry1_8to1_9.replace(packetWrapper.get(Type.INT, 1));
+							packetWrapper.set(Type.INT, 1, replacedBlock);
 						}
 					}
 				});

--- a/core/src/main/java/de/gerrygames/viarewind/replacement/Replacement.java
+++ b/core/src/main/java/de/gerrygames/viarewind/replacement/Replacement.java
@@ -62,7 +62,7 @@ public class Replacement {
 		return item;
 	}
 
-	public BlockState replace(BlockState block) {
-		return new BlockState(id, data==-1 ? block.getData() : data);
+	public int replaceData(int data) {
+		return data == -1 ? data : this.data;
 	}
 }

--- a/core/src/main/java/de/gerrygames/viarewind/replacement/ReplacementRegistry.java
+++ b/core/src/main/java/de/gerrygames/viarewind/replacement/ReplacementRegistry.java
@@ -1,11 +1,8 @@
 package de.gerrygames.viarewind.replacement;
 
-import de.gerrygames.viarewind.storage.BlockState;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import us.myles.ViaVersion.api.minecraft.item.Item;
-
-import java.util.HashMap;
+import us.myles.viaversion.libs.fastutil.ints.Int2ObjectMap;
+import us.myles.viaversion.libs.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class ReplacementRegistry {
 	private final Int2ObjectMap<Replacement> itemReplacements = new Int2ObjectOpenHashMap<>();

--- a/core/src/main/java/de/gerrygames/viarewind/replacement/ReplacementRegistry.java
+++ b/core/src/main/java/de/gerrygames/viarewind/replacement/ReplacementRegistry.java
@@ -1,13 +1,15 @@
 package de.gerrygames.viarewind.replacement;
 
 import de.gerrygames.viarewind.storage.BlockState;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 
 import java.util.HashMap;
 
 public class ReplacementRegistry {
-	private HashMap<Integer, Replacement> itemReplacements = new HashMap<>();
-	private HashMap<Integer, Replacement> blockReplacements = new HashMap<>();
+	private final Int2ObjectMap<Replacement> itemReplacements = new Int2ObjectOpenHashMap<>();
+	private final Int2ObjectMap<Replacement> blockReplacements = new Int2ObjectOpenHashMap<>();
 
 
 	public void registerItem(int id, Replacement replacement) {
@@ -41,13 +43,15 @@ public class ReplacementRegistry {
 		return replacement==null ? item : replacement.replace(item);
 	}
 
-	public BlockState replace(BlockState block) {
-		Replacement replacement = blockReplacements.get(combine(block.getId(), block.getData()));
-		if (replacement==null) replacement = blockReplacements.get(combine(block.getId(), -1));
-		return replacement==null ? block : replacement.replace(block);
+	public Replacement replace(int id, int data) {
+		Replacement replacement = blockReplacements.get(combine(id, data));
+		if (replacement == null) {
+			replacement = blockReplacements.get(combine(id, -1));
+		}
+		return replacement;
 	}
 
-	private static int combine(int id, int data) {
+	public static int combine(int id, int data) {
 		return (id << 16) | (data & 0xFFFF);
 	}
 }

--- a/core/src/main/java/de/gerrygames/viarewind/storage/BlockState.java
+++ b/core/src/main/java/de/gerrygames/viarewind/storage/BlockState.java
@@ -1,32 +1,17 @@
 package de.gerrygames.viarewind.storage;
 
 public class BlockState {
-	private int id;
-	private int data;
 
-	public BlockState(int id, int data) {
-		this.id = id;
-		this.data = data;
+	public static int extractId(int raw) {
+		return raw >> 4;
 	}
 
-	public static BlockState rawToState(int raw) {
-		return new BlockState(raw >> 4, raw & 0xF);
+	public static int extractData(int raw) {
+		return raw & 0xF;
 	}
 
-	public static int stateToRaw(BlockState state) {
-		return (state.getId() << 4) | (state.getData() & 0xF);
+	public static int stateToRaw(int id, int data) {
+		return (id << 4) | (data & 0xF);
 	}
 
-	public int getId() {
-		return this.id;
-	}
-
-	public int getData() {
-		return this.data;
-	}
-
-	@Override
-	public String toString() {
-		return "BlockState{id: " + id + ", data: " + data + "}";
-	}
 }

--- a/core/src/main/java/de/gerrygames/viarewind/utils/Enchantments.java
+++ b/core/src/main/java/de/gerrygames/viarewind/utils/Enchantments.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Enchantments {
-	public static Map<Short, String> ENCHANTMENTS = new HashMap<>();
+	public static final Map<Short, String> ENCHANTMENTS = new HashMap<>();
 
 	static {
 		ENCHANTMENTS.put((short) 1, "I");


### PR DESCRIPTION
The BlockState object had a lot of problems...

Translating a single chunk caused on allocation of at least 65536
objects. Joining a server and walking forwards a bit and taking a jmap
histogram revealed the allocation of ~70 million BlockState objects.
Even worse the replacement was run on Maps with boxed Integers of
which ~110million instances were created just because one player 
moved forward afew blocks.
When this plugin is used on a reasonably big server the GC pressure is
extremely high.
This patch completely eliminates the use of the BlockState and replaces
the Map with a primitive fastutil map.
After this patch, running a few blocks forward only allocates ~12000
boxed Integer objects, which proves that the Chunk replacement was also
the root cause for the huge amount of boxed integers.