### PR TITLE
Use marker property for hologram checking

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/entityreplacements/ArmorStandReplacement.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/entityreplacements/ArmorStandReplacement.java
@@ -108,7 +108,7 @@ public class ArmorStandReplacement implements EntityReplacement {
 		marker = (armorStandFlags & 0x10) != 0;
 
 		State prevState = currentState;
-		if (invisible && name != null) {
+		if (invisible && marker) {
 			currentState = State.HOLOGRAM;
 		} else {
 			currentState = State.ZOMBIE;


### PR DESCRIPTION
Fixes #244 

When HolographicDisplays reloads, it first respawns the armor stands with no name to be updated afterwards, this makes it so ViaRewind's check to differentiate between a regular armor stand and an hologram fails, and attempts to send Zombie metadata with the entity ID that previously belonged to the WitherSkull, crashing the client.
I've changed the check to look for the [Marker](https://minecraft.fandom.com/wiki/Marker) property instead, which is more specific and most hologram plugins do (or should) set.