### PR TITLE
Replace translation keys to raw value in jsonToLegacy

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-all</artifactId>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-bukkit</artifactId>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-bungee</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-core</artifactId>

--- a/core/src/main/java/de/gerrygames/viarewind/utils/ChatUtil.java
+++ b/core/src/main/java/de/gerrygames/viarewind/utils/ChatUtil.java
@@ -1,9 +1,15 @@
 package de.gerrygames.viarewind.utils;
 
+import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.libs.gson.JsonElement;
+import com.viaversion.viaversion.libs.gson.JsonObject;
+import com.viaversion.viaversion.libs.gson.JsonParser;
 import com.viaversion.viaversion.libs.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import com.viaversion.viaversion.libs.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.viaversion.viaversion.protocols.protocol1_12to1_11_1.data.AchievementTranslationMapping;
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.ChatRewriter;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
+import com.viaversion.viaversion.rewriter.ComponentRewriter;
 import de.gerrygames.viarewind.ViaRewind;
 
 import java.util.logging.Level;
@@ -11,15 +17,22 @@ import java.util.regex.Pattern;
 
 public class ChatUtil {
 	private static final Pattern UNUSED_COLOR_PATTERN = Pattern.compile("(?>(?>§[0-fk-or])*(§r|\\Z))|(?>(?>§[0-f])*(§[0-f]))");
+	private static final ComponentRewriter<ClientboundPacketType> LEGACY_REWRITER = new ComponentRewriter<ClientboundPacketType>() {
+		@Override
+		protected void handleTranslate(JsonObject object, String translate) {
+			String text = Protocol1_13To1_12_2.MAPPINGS.getMojangTranslation().get(translate);
+			if (text != null) {
+				object.addProperty("translate", text);
+			}
+		}
+	};
 
 	public static String jsonToLegacy(String json) {
 		if (json == null || json.equals("null") || json.isEmpty()) return "";
 		try {
-			String legacy = LegacyComponentSerializer.legacySection().serialize(ChatRewriter.HOVER_GSON_SERIALIZER.deserialize(json));
-			while (legacy.startsWith("§f")) legacy = legacy.substring(2);
-			return legacy;
-		} catch (Exception ex) {
-			ViaRewind.getPlatform().getLogger().log(Level.WARNING, "Could not convert component to legacy text: " + json, ex);
+			return jsonToLegacy(JsonParser.parseString(json));
+		} catch (Exception e) {
+			ViaRewind.getPlatform().getLogger().log(Level.WARNING, "Could not convert component to legacy text: " + json, e);
 		}
 		return "";
 	}
@@ -30,7 +43,15 @@ public class ChatUtil {
 		} else if (component.isJsonPrimitive()) {
 			return component.getAsString();
 		} else {
-			return jsonToLegacy(component.toString());
+			try {
+				LEGACY_REWRITER.processText(component);
+				String legacy = LegacyComponentSerializer.legacySection().serialize(ChatRewriter.HOVER_GSON_SERIALIZER.deserializeFromTree(component));
+				while (legacy.startsWith("§f")) legacy = legacy.substring(2);
+				return legacy;
+			} catch (Exception ex) {
+				ViaRewind.getPlatform().getLogger().log(Level.WARNING, "Could not convert component to legacy text: " + component, ex);
+			}
+			return "";
 		}
 	}
 

--- a/fabric/pom.xml
+++ b/fabric/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-fabric</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.viaversion</groupId>
     <artifactId>viarewind-parent</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.viaversion</groupId>
             <artifactId>viaversion</artifactId>
-            <version>4.6.0-1.19.4-rc2-SNAPSHOT</version>
+            <version>4.6.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--suppress VulnerableLibrariesLocal -->

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-sponge</artifactId>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.viaversion</groupId>
         <artifactId>viarewind-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>viarewind-velocity</artifactId>


### PR DESCRIPTION
This fixes bossbar, signs and books that contains translation key by replacing them with the en_US values contained in ViaVersion.

I opted for a static ComponentRewriter because both 1.7 and 1.8 require the same processing as we don't have a 1.7-1.8-1.9 diff file anyway.

Tested with 1.12 server and 1.7/1.8 clients.