### PR TITLE
Update JDK to 17, Cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
           check-latest: true
       - name: Cache Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
           check-latest: true
       - name: Publish
         env:


### PR DESCRIPTION
Partially synced from [ViaVersion's #3660](https://github.com/ViaVersion/ViaVersion/pull/3660) except it's the cache that is bumped instead since viarewind already has latest setup-java dependency.