### PR TITLE
Fix race condition when destroy and spawn same entity on 1.7

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/EntityPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/EntityPacketRewriter1_8.java
@@ -102,7 +102,7 @@ public class EntityPacketRewriter1_8 extends VREntityRewriter<ClientboundPackets
 			for (List<Integer> part : parts) {
 				final PacketWrapper destroy = PacketWrapper.create(ClientboundPackets1_7_2_5.REMOVE_ENTITIES, wrapper.user());
 				destroy.write(RewindTypes.INT_ARRAY, part.stream().mapToInt(Integer::intValue).toArray());
-				destroy.scheduleSend(Protocol1_8To1_7_6_10.class);
+				destroy.send(Protocol1_8To1_7_6_10.class);
 			}
 		});
 		protocol.registerClientbound(ClientboundPackets1_8.SET_ENTITY_DATA, new PacketHandlers() {


### PR DESCRIPTION
This fixes a concurrency issue with plugins that reload an entity.

Example: Skin plugins, they reload the player entity for the other people around, Usually with `hidePlayer` and `showPlayer` right after, The problem is that Rewind is currently sending the destroy packet asynchronously, allowing the spawn packet is sent before the destroy packet, causing the entity to no longer appear.

Bug: https://streamable.com/6utqzr