### PR TITLE
Optimize memory usage for 1.7 chunk rewriting

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/api/minecraft/ExtendedBlockStorage.java
+++ b/common/src/main/java/com/viaversion/viarewind/api/minecraft/ExtendedBlockStorage.java
@@ -21,7 +21,7 @@ import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
 import com.viaversion.viaversion.api.minecraft.chunks.NibbleArray;
 
 public class ExtendedBlockStorage {
-	private final byte[] blockLSBArray = new byte[4096];
+	private final byte[] blockLSBArray = new byte[ChunkSection.SIZE];
 
 	private final NibbleArray blockMetadataArray = new NibbleArray(this.blockLSBArray.length);
 	private final NibbleArray blockLightArray = new NibbleArray(this.blockLSBArray.length);

--- a/common/src/main/java/com/viaversion/viarewind/api/type/chunk/BulkChunkType1_7_6.java
+++ b/common/src/main/java/com/viaversion/viarewind/api/type/chunk/BulkChunkType1_7_6.java
@@ -46,7 +46,7 @@ public class BulkChunkType1_7_6 extends Type<Chunk[]> {
 		final short[] primaryBitMask = new short[chunkCount];
 		final short[] additionalBitMask = new short[chunkCount];
 
-        byte[][] dataArrays = new byte[chunkCount][];
+        final byte[][] dataArrays = new byte[chunkCount][];
         int dataSize = 0;
 
 		for (int i = 0; i < chunkCount; i++) {
@@ -54,7 +54,7 @@ public class BulkChunkType1_7_6 extends Type<Chunk[]> {
 			Pair<byte[], Short> chunkData;
 			try {
 				chunkData = ChunkType1_7_6.serialize(chunk);
-                byte[] data = chunkData.key();
+                final byte[] data = chunkData.key();
                 dataArrays[i] = data;
                 dataSize += data.length;
 			} catch (Exception e) {
@@ -66,10 +66,9 @@ public class BulkChunkType1_7_6 extends Type<Chunk[]> {
 			additionalBitMask[i] = chunkData.value();
 		}
 
-        byte[] data = new byte[dataSize];
-
+        final byte[] data = new byte[dataSize];
         int destPos = 0;
-        for (byte[] array : dataArrays) {
+        for (final byte[] array : dataArrays) {
             System.arraycopy(array, 0, data, destPos, array.length);
             destPos += array.length;
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 
 # project
 maven_group=com.viaversion
-maven_version=4.0.7
+maven_version=4.0.8-SNAPSHOT
 maven_description=ViaBackwards addon to allow 1.8.x and 1.7.x clients on newer server versions.
 
 # Smile emoji


### PR DESCRIPTION
This pull request reduces the memory allocated for chunk rewriting
![image](https://github.com/user-attachments/assets/c7bc7a7f-4cac-4fdb-8790-1ab0b0458aa6)
Its a fairly simple optimization as we know the chunk size beforehand

Also for bulk chunk rewriting it no longer uses an ByteArrayOutputStream as once again we know the size beforehand.