### PR TITLE
Fix packet corruption

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
@@ -123,7 +123,7 @@ public class PlayerPacketRewriter1_8 extends RewriterBase<Protocol1_8To1_7_6_10>
 					}
 					// 1.8 clients do keep entity data after respawn, 1.7 clients don't
 					final PacketWrapper setEntityData = PacketWrapper.create(ClientboundPackets1_7_2_5.SET_ENTITY_DATA, wrapper.user());
-					setEntityData.write(Types.VAR_INT, tracker.clientEntityId());
+					setEntityData.write(Types.INT, tracker.clientEntityId());
 					setEntityData.write(Types1_7_6_10.ENTITY_DATA_LIST, tracker.getEntityData());
 					setEntityData.send(Protocol1_8To1_7_6_10.class);
 				});


### PR DESCRIPTION
Entity metadata on 1.7.10 uses an int for entity id, not a var int. This caused very rare random crashes on respawns for me as it corrupted the packet.