### PR TITLE
Fix tablist ping updates on 1.7 causing a full tab rebuild

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
@@ -300,15 +300,9 @@ public class PlayerPacketRewriter1_8 extends RewriterBase<Protocol1_8To1_7_6_10>
 					if (gameProfile == null) {
 						continue;
 					}
-					PacketWrapper packet = PacketWrapper.create(ClientboundPackets1_7_2_5.PLAYER_INFO, wrapper.user());
-					packet.write(Types.STRING, gameProfile.getDisplayName());
-					packet.write(Types.BOOLEAN, false);
-					packet.write(Types.SHORT, (short) gameProfile.ping);
-					packet.scheduleSend(Protocol1_8To1_7_6_10.class);
-
 					gameProfile.ping = ping;
 
-					packet = PacketWrapper.create(ClientboundPackets1_7_2_5.PLAYER_INFO, wrapper.user());
+                    PacketWrapper packet = PacketWrapper.create(ClientboundPackets1_7_2_5.PLAYER_INFO, wrapper.user());
 					packet.write(Types.STRING, gameProfile.getDisplayName());
 					packet.write(Types.BOOLEAN, true);
 					packet.write(Types.SHORT, (short) ping);


### PR DESCRIPTION
This PR modifies how 1.7 Tablist PlayerInfo packets are translated. Currently, when updating a player's ping in the tablist, the translation layer removes the existing PlayerInfo from the client and resends a new one.

However, this full rebuild is unnecessary for ping updates, as the client will correctly update the ping value associated with an existing entry by their name. A full rebuild is only required when modifying the String value (name)

The deletion of PlayerInfo could in some cases, cause a viewed player/npc's skin to never finish loading (Only for users with slower internet connections). Rebuilding the entire tab also causes unneeded network & cpu usage (although very minimal)

**This change addresses several issues:**
- Allows for individual ping updates while also retaining the tab's order
- Allows for ping updates without completely rebuilding the tablist
- Fixes race conditions where players or NPCs may spawn without their skin.
- Reduces unnecessary network usage.

**Before:**
<img width="1920" height="1017" alt="2025-07-13_00 58 23" src="https://github.com/user-attachments/assets/f815cdc4-0dff-4397-a316-1f3a757469b0" />
**After**
<img width="1920" height="1017" alt="2025-07-13_00 57 54" src="https://github.com/user-attachments/assets/9a63bf41-0f7e-4265-b75e-9e79428180df" />

**Doesn't cause duplicated entries (Sending a different String name value without removing the old one would cause duplicated entries)**
<img width="1920" height="1017" alt="2025-07-13_00 55 00" src="https://github.com/user-attachments/assets/8f4d9aa7-ee78-4f8c-9fe5-23e9defe3b3b" />
