### PR TITLE
Fixed 1.7 holograms not being able to be hidden

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -48,6 +48,7 @@ public class VirtualHologramEntity {
     private float headYaw;
     private boolean small = false;
     private boolean marker = false;
+    private boolean showNametag = false;
 
     public VirtualHologramEntity(final UserConnection user, final int entityId) {
         this.user = user;
@@ -98,6 +99,7 @@ public class VirtualHologramEntity {
         // Filter armor stand data to calculate emulation
         byte flags = 0;
         byte armorStandFlags = 0;
+        byte nameTagFlags = 0;
         for (EntityData entityData : entityDataTracker) {
             if (entityData.id() == 0 && entityData.dataType() == EntityDataTypes1_8.BYTE) {
                 flags = ((Number) entityData.getValue()).byteValue();
@@ -106,11 +108,14 @@ public class VirtualHologramEntity {
                 if (name != null && name.isEmpty()) name = null;
             } else if (entityData.id() == 10 && entityData.dataType() == EntityDataTypes1_8.BYTE) {
                 armorStandFlags = ((Number) entityData.getValue()).byteValue();
+            } else if (entityData.id() == 3 && entityData.dataType() == EntityDataTypes1_8.BYTE) {
+                nameTagFlags = ((Number) entityData.getValue()).byteValue();
             }
         }
         final boolean invisible = (flags & 0x20) != 0;
         small = (armorStandFlags & 0x01) != 0;
         marker = (armorStandFlags & 0x10) != 0;
+        showNametag = (nameTagFlags & 0x01) != 0;
 
         State prevState = currentState;
         if (invisible && name != null) {
@@ -253,7 +258,7 @@ public class VirtualHologramEntity {
         final List<EntityData> entityDataList = new ArrayList<>();
         entityDataList.add(new EntityData(EntityDataIndex1_7_6_10.ABSTRACT_AGEABLE_AGE.getIndex(), EntityDataTypes1_7_6_10.INT, -1700000));
         entityDataList.add(new EntityData(EntityDataIndex1_7_6_10.LIVING_ENTITY_BASE_NAME_TAG.getIndex(), EntityDataTypes1_7_6_10.STRING, name));
-        entityDataList.add(new EntityData(EntityDataIndex1_7_6_10.LIVING_ENTITY_BASE_NAME_TAG_VISIBILITY.getIndex(), EntityDataTypes1_7_6_10.BYTE, (byte) 1));
+        entityDataList.add(new EntityData(EntityDataIndex1_7_6_10.LIVING_ENTITY_BASE_NAME_TAG_VISIBILITY.getIndex(), EntityDataTypes1_7_6_10.BYTE, (byte) (showNametag ? 1 : 0)));
 
         wrapper.write(RewindTypes.ENTITY_DATA_LIST1_7, entityDataList);
     }


### PR DESCRIPTION
This PR fixes 1.7 holograms from forcefully showing the nametag. Now the hologram will show/hide the nametag based on the ArmorStand's state.

This is useful for dynamically showing & hiding the hologram lines without having to remove the entity 

Before: (Empty line)
<img width="1920" height="1017" alt="2025-07-13_14 25 59" src="https://github.com/user-attachments/assets/7d1d7f6d-eff0-4337-9cdb-848b5cf69c64" />

After: (Line is hidden)
<img width="1920" height="1017" alt="2025-07-13_14 21 43" src="https://github.com/user-attachments/assets/d1bab294-4515-41d5-82f2-8f9019ed365b" />
