### PR TITLE
Hologram height fixes

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -148,7 +148,19 @@ public class VirtualHologramEntity {
             entityHeadLook.send(Protocol1_8To1_7_6_10.class);
         } else if (currentState == State.HOLOGRAM) {
             // Don't ask me where this offset is coming from
-            teleportEntity(entityIds[0], locX, (locY + (marker ? 54.3625 : small ? 56 : 57) - 0.16), locZ, 0, 0); // Skull
+            teleportEntity(entityIds[0], locX, (locY + getOffset()), locZ, 0, 0); // Skull
+        }
+    }
+
+    private double getOffset() {
+        double baseOffset = 54.35;
+
+        if (marker) {
+            return baseOffset;
+        } else if (small) {
+            return baseOffset + 0.9875;
+        } else {
+            return baseOffset + (0.9875 * 2);
         }
     }
 
@@ -256,13 +268,12 @@ public class VirtualHologramEntity {
             entityIds = new int[]{entityId};
         } else if (currentState == State.HOLOGRAM) {
             final int[] entityIds = {entityId, additionalEntityId()};
-            final double offsetY = (locY + (marker ? 54.3625 : small ? 56 : 57)) - 0.16;
 
             final PacketWrapper spawnSkull = PacketWrapper.create(ClientboundPackets1_7_2_5.ADD_ENTITY, user);
             spawnSkull.write(Types.VAR_INT, entityIds[0]);
             spawnSkull.write(Types.BYTE, (byte) 66);
             spawnSkull.write(Types.INT, (int) (locX * 32.0));
-            spawnSkull.write(Types.INT, (int) (offsetY * 32.0));
+            spawnSkull.write(Types.INT, (int) ((locY + getOffset()) * 32.0));
             spawnSkull.write(Types.INT, (int) (locZ * 32.0));
             spawnSkull.write(Types.BYTE, (byte) 0);
             spawnSkull.write(Types.BYTE, (byte) 0);
@@ -272,8 +283,8 @@ public class VirtualHologramEntity {
             final List<EntityData> squidEntityData = new ArrayList<>();
             squidEntityData.add(new EntityData(0, EntityDataTypes1_8.BYTE, (byte) 32));
 
-            spawnEntity(entityIds[0], EntityTypes1_8.EntityType.SQUID.getId(), locX, offsetY, locZ, squidEntityData);
-            spawnEntity(entityIds[1], EntityTypes1_8.EntityType.HORSE.getId(), locX, offsetY + 0.74, locZ, new ArrayList<>());
+            spawnEntity(entityIds[0], EntityTypes1_8.EntityType.SQUID.getId(), locX, locY + getOffset(), locZ, squidEntityData);
+            spawnEntity(entityIds[1], EntityTypes1_8.EntityType.HORSE.getId(), locX, locY + (getOffset() + 0.68), locZ, new ArrayList<>());
 
             this.entityIds = entityIds;
         }


### PR DESCRIPTION
Just a quick fix to sync the position of all hologram types to what they are in 1.8, as I disregarded the positioning of non-marker holograms when I implemented my hologram movement fix.

Normal 1.8 Positions, I have position all holograms to have their nametag at the top of the block
<img width="1920" height="1017" alt="2025-07-23_12 11 48" src="https://github.com/user-attachments/assets/0cc2a1c5-0c0b-4265-aa09-0a38f44c7f79" />

VR v4.0.8
<img width="1920" height="1017" alt="2025-07-23_12 13 18" src="https://github.com/user-attachments/assets/b04c7862-5717-49f4-9927-e8789bd60c06" />

With this fix:
<img width="1920" height="1080" alt="2025-07-23_12 10 00" src="https://github.com/user-attachments/assets/775f7b29-5276-4e21-adb1-7d5c1593a4db" />


