### PR TITLE
fix server crasher exploit

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/utils/ChatUtil.java
+++ b/common/src/main/java/com/viaversion/viarewind/utils/ChatUtil.java
@@ -66,7 +66,10 @@ public class ChatUtil {
 			try {
 				LEGACY_REWRITER.processText(null, component);
 				String legacy = ComponentUtil.jsonToLegacy(component);
-				while (legacy.startsWith("§f")) legacy = legacy.substring(2);
+                int attempts = 0;
+                while (legacy.startsWith("§f") && attempts++ < 10) {
+                    legacy = legacy.substring(2);
+                }
 				return legacy;
 			} catch (Exception ex) {
 				if (!Via.getConfig().isSuppressConversionWarnings()) {


### PR DESCRIPTION
limit legacy string trimming attempts to prevent infinite loops


```
"Netty Epoll Server IO #3" #114 [290646] daemon prio=5 os_prio=0 cpu=228692.18ms elapsed=1116.19s tid=0x00007efca0013520 nid=290646 runnable  [0x00007efc667f5000]
   java.lang.Thread.State: RUNNABLE
	at com.viaversion.viarewind.utils.ChatUtil.jsonToLegacy(ChatUtil.java:69)
	at com.viaversion.viarewind.protocol.v1_9to1_8.rewriter.PlayerPacketRewriter1_9$12.lambda$register$0(PlayerPacketRewriter1_9.java:441)
	at com.viaversion.viarewind.protocol.v1_9to1_8.rewriter.PlayerPacketRewriter1_9$12$$Lambda/0x00007efd9d3df560.handle(Unknown Source)
	at com.viaversion.viaversion.api.protocol.remapper.PacketHandlers.handle(PacketHandlers.java:179)
	at com.viaversion.viaversion.api.protocol.AbstractProtocol.transform(AbstractProtocol.java:418)
	at com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:436)
	at com.viaversion.viaversion.protocol.ProtocolPipelineImpl.transform(ProtocolPipelineImpl.java:122)
	at com.viaversion.viaversion.connection.UserConnectionImpl.transform(UserConnectionImpl.java:355)
	at com.viaversion.viaversion.connection.UserConnectionImpl.transformServerbound(UserConnectionImpl.java:336)
```