### PR TITLE
Send the delayed potion spawn's velocity as its own packet in 1.9->1.8

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -604,6 +604,15 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         addEntity.write(Types.SHORT, spawn.velocityY());
         addEntity.write(Types.SHORT, spawn.velocityZ());
         addEntity.send(Protocol1_9To1_8.class); // Before the entity data is sent
+
+        // 1.8 clients never apply a potion spawn's velocity - vanilla servers send it in a separate
+        // velocity packet after the spawn, so do the same
+        final PacketWrapper setEntityMotion = PacketWrapper.create(ClientboundPackets1_8.SET_ENTITY_MOTION, event.user());
+        setEntityMotion.write(Types.VAR_INT, event.entityId());
+        setEntityMotion.write(Types.SHORT, spawn.velocityX());
+        setEntityMotion.write(Types.SHORT, spawn.velocityY());
+        setEntityMotion.write(Types.SHORT, spawn.velocityZ());
+        setEntityMotion.send(Protocol1_9To1_8.class);
     }
 
     private void handleEntityData(EntityDataHandlerEvent event, EntityData entityData) {


### PR DESCRIPTION
Didn't notice this before since I was using patcher in testing (which fixed this issue), but pre 1.9 vanilla clients never apply a potion spawn's velocity (due to how they're spawned in). NetHandlerPlayClient.handleSpawnObject zeroes the data before the generic data > 0 → setVelocity, so the shorts in the spawn packet are dropped. A vanilla server sends the arc in a separate velocity packet after the spawn (EntityTrackerEntry), which is why the data <= 0 branch here already does exactly that.

Since [#703](https://github.com/ViaVersion/ViaRewind/pull/703) holds the potion spawn back and folds any incoming SET_ENTITY_MOTION into it, that packet is currently lost for every 1.9+ server.

This re-sends the held velocity as its own packet right after the delayed spawn, matching both the vanilla tracker and the existing data <= 0 path. Tested on 1.8.9 vanilla, lunar, badlion, and forge with & without patcher.